### PR TITLE
Wrapping double quotes around string product properties since these c…

### DIFF
--- a/impactutils/transfer/pdlsender.py
+++ b/impactutils/transfer/pdlsender.py
@@ -140,7 +140,7 @@ class PDLSender(Sender):
                     '--property-%s=%s'
                     % (propkey, propvalue.strftime(DATE_TIME_FMT)[0:23]))
             elif isinstance(propvalue, str):
-                prop_nuggets.append('--property-%s=%s' % (propkey, propvalue))
+                prop_nuggets.append('--property-%s="%s"' % (propkey, propvalue))
             else:
                 prop_nuggets.append('--property-%s=%s' %
                                     (propkey, str(propvalue)))


### PR DESCRIPTION
…an have spaces in them, which mess up the call to the java command line for pdlsender.