### PR TITLE
Add an explicit encoding argument to the open() of the city file to

### DIFF
--- a/impactutils/mapping/city.py
+++ b/impactutils/mapping/city.py
@@ -3,15 +3,15 @@ import numpy as np
 import zipfile
 import tempfile
 import sys
-if sys.version_info.major == 3:
-    import urllib.request as request
-else:
-    import urllib2 as request
 import io
 import os.path
 
 from impactutils.extern.openquake.geodetic import geodetic_distance
 import pandas as pd
+if sys.version_info.major == 3:
+    import urllib.request as request
+else:
+    import urllib2 as request
 
 GEONAME_URL = 'http://download.geonames.org/export/dump/cities1000.zip'
 
@@ -127,7 +127,7 @@ class Cities(object):
                   'lon': [],
                   'iscap': [],
                   'pop': []}
-        f = open(cityfile, 'rt')
+        f = open(cityfile, 'rt', encoding='latin-1')
         for line in f.readlines():
             parts = line.split('\t')
             tname = parts[2].strip()
@@ -172,7 +172,7 @@ class Cities(object):
         Returns:
             Number of cities contained in this object.
         """
-        return len(df)
+        return len(self._dataframe)
 
     def save(self, filename):
         """Save City internal dataframe to CSV file.
@@ -199,7 +199,7 @@ class Cities(object):
         Raises:
             KeyError: When column(s) are not in the list of dataframe columns.
         """
-        if column not in self._dataframe.columns:
+        if 'column' not in self._dataframe.columns:
             raise KeyError('Column not in list of DataFrame columns')
         if pd.__version__ < '0.17.0':
             self._dataframe = self._dataframe.sort(columns=columns,

--- a/impactutils/mapping/city.py
+++ b/impactutils/mapping/city.py
@@ -199,8 +199,10 @@ class Cities(object):
         Raises:
             KeyError: When column(s) are not in the list of dataframe columns.
         """
-        if 'column' not in self._dataframe.columns:
-            raise KeyError('Column not in list of DataFrame columns')
+        bad_columns = set(columns).difference(set(self._dataframe.columns()))
+        if bad_columns:
+            raise KeyError('Column(s) not in list of DataFrame columns: %s' %
+                           str(bad_columns))
         if pd.__version__ < '0.17.0':
             self._dataframe = self._dataframe.sort(columns=columns,
                                                    ascending=ascending)


### PR DESCRIPTION
avoid errors when the default local encoding is not 'UTF-8'. "latin-1"
is recommended as it covers the first 256 characters of Unicode. Also
took the opportunity to fix two bugs (undefined variables) and some
annoying warnings.
Mike: please make sure the "column" to "'column'" fix is correct. It was an undefined variable; I think the quotes are the right way to fix it, but I'm not sure.