### PR TITLE
bugfix in pdlsender cancel

### DIFF
--- a/impactutils/transfer/pdlsender.py
+++ b/impactutils/transfer/pdlsender.py
@@ -197,7 +197,7 @@ class PDLSender(Sender):
         self._properties['directory'] = ''
         cmd = self._pdlcmd
         for propkey, propvalue in self._properties.items():
-            cmd = cmd.replace('[' + propkey.upper() + ']', propvalue)
+            cmd = cmd.replace('[' + propkey.upper() + ']', str(propvalue))
 
         retcode, stdout, stderr = get_command_output(cmd)
         if not retcode:


### PR DESCRIPTION
Apparently I am the lucky one to first cancel/delete a shakemap in v4. 