### PR TITLE
Updated commonly raised exceptions to be more specific

### DIFF
--- a/impactutils/colors/cpalette.py
+++ b/impactutils/colors/cpalette.py
@@ -1,6 +1,11 @@
+# third party imports
 from matplotlib.colors import LinearSegmentedColormap
 import numpy as np
 import pandas as pd
+
+# local imports
+from impactutils.exceptions import ConsistentLengthError, UnsupportedArgumentError
+
 
 MMI = {'z0': np.arange(0, 10),
        'z1': np.arange(1, 11),
@@ -104,8 +109,8 @@ class ColorPalette(object):
         """
         # validate that lengths are all identical
         if len(z0) != len(z1) != len(rgb0) != len(rgb1):
-            raise Exception('Lengths of input sequences to ColorPalette() '
-                            'must be identical.')
+            raise ConsistentLengthError('Lengths of input sequences to ColorPalette() '
+                                      'must be identical.')
         self._is_log = is_log
         z0 = np.array(z0)
         z1 = np.array(z1)
@@ -179,7 +184,7 @@ class ColorPalette(object):
             ColorPalette object.
         """
         if preset not in PALETTES:
-            raise Exception(
+            raise UnsupportedArgumentError(
                 f'Preset {preset} not in list of supported presets.')
         z0 = PALETTES[preset]['z0'].copy()
         z1 = PALETTES[preset]['z1'].copy()
@@ -277,8 +282,8 @@ class ColorPalette(object):
         """
         # use the whole dynamic range of the colormap
         if len(z0) != len(z1):
-            raise Exception('Lengths of input sequences to '
-                            'ColorPalette.fromColorMap() must be identical.')
+            raise ConsistentLengthError('Lengths of input sequences to '
+                                      'ColorPalette.fromColorMap() must be identical.')
         zmin = np.min(z0)
         zmax = np.max(z1)
         rgb0 = []

--- a/impactutils/exceptions.py
+++ b/impactutils/exceptions.py
@@ -1,0 +1,24 @@
+class ImpactUtilsError(Exception):
+    """Base class for all ImpactUtils exceptions/errors.
+    """
+    pass
+
+
+class ConsistentLengthError(ImpactUtilsError):
+    """Handles errors when lengths input arrays are not equal."""
+    pass
+
+
+class PDLError(ImpactUtilsError):
+    """Handles errors related to pdl."""
+    pass
+
+
+class RequiredArgumentError(ImpactUtilsError):
+    """Handles errors for missing arguments."""
+    pass
+
+
+class UnsupportedArgumentError(ImpactUtilsError):
+    """Handles errors for unsupported arguments."""
+    pass

--- a/impactutils/mapping/scalebar.py
+++ b/impactutils/mapping/scalebar.py
@@ -4,6 +4,10 @@ import matplotlib
 from cartopy.mpl.geoaxes import GeoAxes
 import cartopy
 
+# local imports
+from impactutils.exceptions import RequiredArgumentError
+
+
 # CONSTANTS
 BAR_HEIGHT_FONT = 0.75    # bar height in fontsize units
 MAX_BAR_HEIGHT = 0.5      # maximum bar height in inches
@@ -136,24 +140,25 @@ def draw_scale(ax, pos='ll', padx=0.1, pady=0.1, font_size=None, units='km',
     hasbar = bar_length is not None
     hasdiv = divisions is not None
     if hasbar + hasdiv != 0 and hasbar + hasdiv != 2:
-        raise Exception('You must specify BOTH bar_length AND divisions.')
+        raise RequiredArgumentError(
+            'You must specify BOTH bar_length AND divisions.')
 
     if divisions is not None:
         if divisions not in [2, 3, 4, 5, 6]:
-            raise Exception('Divisions must be an integer in the range 2-6.')
+            raise ValueError('Divisions must be an integer in the range 2-6.')
 
     # check units
     if units not in UNITS:
-        raise Exception('Input scale bar units must be either "km" or "mi"')
+        raise ValueError('Input scale bar units must be either "km" or "mi"')
 
     # check position
     if pos not in ['ll', 'lr', 'ul', 'ur']:
-        raise Exception("Input scale bar position must be one of "
-                        "'ll', 'lr', 'ul', 'ur'")
+        raise ValueError("Input scale bar position must be one of "
+                         "'ll', 'lr', 'ul', 'ur'")
 
     # Verify that the input axes are in fact GeoAxes
     if not isinstance(ax, GeoAxes):
-        raise Exception('Input axes object must be a Cartopy GeoAxes.')
+        raise ValueError('Input axes object must be a Cartopy GeoAxes.')
 
     # Get the left, right, bottom, top edges in data units
     xmin, xmax = ax.get_xlim()

--- a/impactutils/rupture/distance.py
+++ b/impactutils/rupture/distance.py
@@ -10,6 +10,7 @@ from openquake.hazardlib.gsim.base import GMPE
 from openquake.hazardlib.gsim import base
 
 # local imports
+from impactutils.exceptions import ConsistentLengthError
 from impactutils.rupture.edge_rupture import EdgeRupture
 
 
@@ -185,7 +186,8 @@ def get_distance(methods, lat, lon, dep, rupture, dx=0.5):
 
     # Check dimensions of site coordinates
     if (lat.shape != lon.shape) or (lat.shape != dep.shape):
-        raise Exception('lat, lon, and dep must have the same shape.')
+        raise ConsistentLengthError(
+            'lat, lon, and dep must have the same shape.')
 
     # -------------------------------------------------------------------------
     # Point distances

--- a/impactutils/rupture/factory.py
+++ b/impactutils/rupture/factory.py
@@ -326,18 +326,18 @@ def text_to_json(file, new_format=True):
         parts = line.split()
         if len(parts) == 1:
             if new_format:
-                raise ShakeLibException(
+                raise Exception(
                     f'Rupture file {file} has unspecified delimiters.')
             parts = line.split(',')
             if len(parts) == 1:
-                raise ShakeLibException(
+                raise Exception(
                     f'Rupture file {file} has unspecified delimiters.')
 
         if len(parts) != 3:
             msg = f'Rupture file {file} is not in lat, lon, depth format.'
             if new_format:
                 f'Rupture file {file} is not in lon, lat, depth format.'
-            raise ShakeLibException(msg)
+            raise Exception(msg)
 
         parts = [float(p) for p in parts]
         if not new_format:

--- a/impactutils/rupture/origin.py
+++ b/impactutils/rupture/origin.py
@@ -174,12 +174,12 @@ class Origin(object):
                  'ALL': {'rake': 45.0, 'dip': 90.0}}
 
         if mech not in list(mechs.keys()):
-            raise Exception(
+            raise ValueError(
                 f'Mechanism must be one of: {str(list(mechs.keys()))}')
 
         if dip is not None:
             if dip < 0 or dip > 90:
-                raise Exception('Dip must be in range 0-90 degrees.')
+                raise ValueError('Dip must be in range 0-90 degrees.')
         else:
             dip = mechs[mech]['dip']
 
@@ -189,7 +189,7 @@ class Origin(object):
             if rake > 180:
                 rake -= 360
             if rake < -180 or rake > 180:
-                raise Exception(
+                raise ValueError(
                     'Rake must be transformable to be in range -180 to 180 '
                     'degrees.')
         else:

--- a/impactutils/rupture/quad_rupture.py
+++ b/impactutils/rupture/quad_rupture.py
@@ -11,16 +11,19 @@ from openquake.hazardlib.geo.geodetic import point_at
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.geo.utils import OrthographicProjection
 
-from impactutils.vectorutils.ecef import latlon2ecef
-from impactutils.vectorutils.ecef import ecef2latlon
-from impactutils.vectorutils.vector import Vector
-from impactutils.time.ancient_time import HistoricTime
+
+# local imports
 from impactutils.rupture.base import Rupture
+from impactutils.exceptions import ConsistentLengthError
 from impactutils.rupture.utils import (_quad_distance, get_quad_width,
                                        get_quad_normal, get_vertical_vector,
                                        get_quad_length, is_quad)
 from impactutils.rupture import gc2
 import impactutils.rupture.constants as constants
+from impactutils.time.ancient_time import HistoricTime
+from impactutils.vectorutils.ecef import latlon2ecef
+from impactutils.vectorutils.ecef import ecef2latlon
+from impactutils.vectorutils.vector import Vector
 
 
 class QuadRupture(Rupture):
@@ -238,11 +241,11 @@ class QuadRupture(Rupture):
         """
         if not (len(xp0) == len(yp0) == len(xp1) == len(yp1) ==
                 len(zp) == len(dips) == len(widths)):
-            raise Exception(
+            raise ConsistentLengthError(
                 'Number of xp0,yp0,xp1,yp1,zp,widths,dips points must be '
                 'equal.')
         if strike is not None and len(xp0) != len(strike) and len(strike) != 1:
-            raise Exception(
+            raise TypeError(
                 'Strike must be None or an array of one value or the '
                 'same length as trace coordinates.')
 
@@ -480,7 +483,7 @@ class QuadRupture(Rupture):
                 strike) == len(dip):
             pass
         else:
-            raise Exception(
+            raise ConsistentLengthError(
                 'Number of px, py, pz, dx, dy, length, width, '
                 'strike, dip points must be '
                 'equal.')
@@ -581,13 +584,13 @@ class QuadRupture(Rupture):
            len(yp3) == len(zp3):
             pass
         else:
-            raise Exception('All vectors specifying quadrilateral '
-                            'vertices must have the same length.')
+            raise ConsistentLengthError('All vectors specifying quadrilateral '
+                                        'vertices must have the same length.')
 
         nq = len(xp0)
         if group_index is not None:
             if len(group_index) != nq:
-                raise Exception(
+                raise ConsistentLengthError(
                     "group_index must have same length as vertices.")
         else:
             group_index = np.array(range(nq))

--- a/impactutils/time/timeutils.py
+++ b/impactutils/time/timeutils.py
@@ -18,6 +18,9 @@ import pytz
 from shapely.geometry import shape, Point
 from shapely.ops import transform
 
+# local imports
+from impactutils.exceptions import RequiredArgumentError, UnsupportedArgumentError
+
 
 TIMEFMT = '%Y-%m-%dT%H:%M:%S'
 TIMEOUT = 30  # number of seconds to wait for urlopen requests
@@ -345,17 +348,17 @@ class TimeConversion(object):
             }
         else:
             if raster_shape is None:
-                raise Exception('For a custom tiff, the shape of the array '
-                                'must be specified as a tuple. Example: (9000, 18000).')
+                raise RequiredArgumentError('For a custom tiff, the shape of the array '
+                                            'must be specified as a tuple. Example: (9000, 18000).')
             if extents is None:
-                raise Exception('For a custom tiff, the extents '
-                                'must be specified.')
+                raise RequiredArgumentError('For a custom tiff, the extents '
+                                            'must be specified.')
             if resolution is None:
-                raise Exception('For a custom tiff, the resolution of the tiff '
-                                'must be specified as a tuple. Example: (0.02, 0.02).')
+                raise RequiredArgumentError('For a custom tiff, the resolution of the tiff '
+                                            'must be specified as a tuple. Example: (0.02, 0.02).')
             if timezone_coding is None:
-                raise Exception('For a custom tiff, the path to the country code '
-                                'file must be specified.')
+                raise RequiredArgumentError('For a custom tiff, the path to the country code '
+                                            'file must be specified.')
             self._filepath = tiff
             self._shape = raster_shape
             self._resolution = resolution
@@ -386,8 +389,8 @@ class TimeConversion(object):
         # Validate rounding option
         rounding_option = ['floor, ceil, round']
         if rounding_method not in ['floor', 'ceil', 'round']:
-            raise Exception(f"{rounding_method} is not a valid 'rounding_method'."
-                            f" It must be one of {rounding_option}.")
+            raise UnsupportedArgumentError(f"{rounding_method} is not a valid 'rounding_method'."
+                                           f" It must be one of {rounding_option}.")
         # Get the extents of the raster
         min_lon = self._extents['Lower Left'][0]
         max_lon = self._extents['Lower Right'][0]

--- a/impactutils/transfer/pdlsender.py
+++ b/impactutils/transfer/pdlsender.py
@@ -11,6 +11,7 @@ from .sender import Sender
 
 # local imports
 from impactutils.io.cmd import get_command_output
+from impactutils.exceptions import PDLError
 
 DATE_TIME_FMT = '%Y-%m-%dT%H:%M:%S.%f'
 
@@ -98,7 +99,7 @@ class PDLSender(Sender):
         """Send local file or directory via PDL.
 
         Raises:
-            Exception when:
+            PDLError when:
              - number of local_files is greater than 1.
              - PDL command fails for any reason.
 
@@ -109,7 +110,7 @@ class PDLSender(Sender):
         # we can really only support sending of one file, so error out
         # if someone has specified more than one.
         if len(self._local_files) > 1:
-            raise Exception('For PDL, you may only send one file at a time.')
+            raise PDLError('For PDL, you may only send one file at a time.')
 
         # build pdl command line from properties
         cmd = self._pdlcmd
@@ -173,7 +174,7 @@ class PDLSender(Sender):
         retcode, stdout, stderr = get_command_output(cmd)
         if not retcode:
             fmt = f'Could not send product "{retcode}" due to error "{stdout + stderr}"'
-            raise Exception(fmt)
+            raise PDLError(fmt)
 
         # return the number of files we just sent
         nfiles = 0
@@ -222,6 +223,6 @@ class PDLSender(Sender):
         retcode, stdout, stderr = get_command_output(cmd)
         if not retcode:
             fmt = f'Could not delete product "{retcode}" due to error "{stdout + stderr}"'
-            raise Exception(fmt)
+            raise PDLError(fmt)
 
         return stdout

--- a/impactutils/transfer/sender.py
+++ b/impactutils/transfer/sender.py
@@ -3,6 +3,9 @@
 # stdlib imports
 import os.path
 
+# local imports
+from impactutils.exceptions import RequiredArgumentError
+
 
 class Sender(object):
     '''
@@ -48,19 +51,20 @@ class Sender(object):
         self._properties = properties
         for prop in self._required_properties:
             if prop not in self._properties:
-                raise Exception(f'Required property "{prop}" not specified.')
+                raise RequiredArgumentError(
+                    f'Required property "{prop}" not specified.')
 
         if local_files is not None:
             if not isinstance(local_files, list):
-                raise Exception('Input files must be a list')
+                raise TypeError('Input files must be a list')
             for f in local_files:
                 if not os.path.isfile(f):
-                    raise Exception(
+                    raise FileNotFoundError(
                         f'Input file {f} could not be found')
 
         if local_directory is not None:
             if not os.path.isdir(local_directory):
-                raise Exception(
+                raise FileNotFoundError(
                     f'Input directory {directory} could not be found')
         if local_files is not None:
             self._local_files = local_files
@@ -80,12 +84,12 @@ class Sender(object):
     def addFiles(self, local_files):
         for f in files:
             if not os.path.isfile(f):
-                raise Exception(f'Input file {f} could not be found')
+                raise FileNotFoundError(f'Input file {f} could not be found')
         self._local_files += local_files
 
     def changeDirectory(self, local_directory, directory_alias=None):
         if not os.path.isdir(local_directory):
-            raise Exception(
+            raise FileNotFoundError(
                 f'Input directory {directory} could not be found')
         self._local_directory = local_directory
         self._directory_alias = directory_alias


### PR DESCRIPTION
The commonly raised exceptions were replaced by a more specific error defined by the ImpactUtilsError base class. The common errors include:

- ConsistentLengthError: may be raised when arguments that are arrays must be a consistent length or shape. 
- PDLError: may be raised when sending/canceling products.
- RequiredArgumentError: may be raised when arguments are required, but are not positional arguments.
- UnsupportedArgumentError: may be raised when an argument requires a specific value or range of values.

closes #119 